### PR TITLE
Update p4xdp_kern.c

### DIFF
--- a/misc/native/p4xdp_kern.c
+++ b/misc/native/p4xdp_kern.c
@@ -2,6 +2,7 @@
 #include <bpf/bpf_helpers.h>
 #include "utils.h"
 #include "types.h"
+#include "stdio.h"
 #include "p4xdp_tab.h"
 
 


### PR DESCRIPTION
stdio.h is required to avoid the message
"error: use of undeclared identifier 'NULL'"