### PR TITLE
Added lsigp[4|6]metric sensor

### DIFF
--- a/misc/sensor/lsigp-isis.txt
+++ b/misc/sensor/lsigp-isis.txt
@@ -75,3 +75,28 @@ skip 0
 column 1 name val
 .
 exit
+
+sensor lsigp4metric
+path lsigp4metric/peer/peer
+prefix freertr-lsigp4metric
+prepend lsigp4_metric_
+command show ipv4 isis 1 metric
+name 0 proto="isis1",ifc=
+key name lsigp4metric/peer
+replace \. _
+column 4 name metric
+.
+exit
+
+sensor lsigp6metric
+path lsigp6metric/peer/peer
+prefix freertr-lsigp6metric
+prepend lsigp6_metric_
+command show ipv6 isis 1 metric
+name 0 proto="isis1",ifc=
+key name lsigp6metric/peer
+replace \. _
+column 4 name metric
+.
+exit
+

--- a/misc/sensor/lsigp-lsrp.txt
+++ b/misc/sensor/lsigp-lsrp.txt
@@ -75,3 +75,28 @@ skip 0
 column 1 name val
 .
 exit
+
+sensor lsigp4metric
+path lsigp4metric/peer/peer
+prefix freertr-lsigp4metric
+prepend lsigp4_metric_
+command show ipv4 lsrp 1 metric
+name 0 proto="lsrp1",ifc=
+key name lsigp4metric/peer
+replace \. _
+column 4 name metric
+.
+exit
+
+sensor lsigp6metric
+path lsigp6metric/peer/peer
+prefix freertr-lsigp6metric
+prepend lsigp6_metric_
+command show ipv6 lsrp 1 metric
+name 0 proto="lsrp1",ifc=
+key name lsigp6metric/peer
+replace \. _
+column 4 name metric
+.
+exit
+

--- a/misc/sensor/lsigp-ospf.txt
+++ b/misc/sensor/lsigp-ospf.txt
@@ -76,3 +76,27 @@ skip 0
 column 1 name val
 .
 exit
+
+sensor lsigp4metric
+path lsigp4metric/peer/peer
+prefix freertr-lsigp4metric
+prepend lsigp4_metric_
+command show ipv4 ospf 1 metric
+name 0 proto="ospf1",ifc=
+key name lsigp4metric/peer
+replace \. _
+column 4 name metric
+.
+exit
+
+sensor lsigp6metric
+path lsigp6metric/peer/peer
+prefix freertr-lsigp6metric
+prepend lsigp6_metric_
+command show ipv6 ospf 1 metric
+name 0 proto="ospf1",ifc=
+key name lsigp6metric/peer
+replace \. _
+column 4 name metric
+.
+exit


### PR DESCRIPTION
As discussed, added lsigp[4|6] for ISIS, LSPR and OSPF in `misc/sensor/` needed to render active measurement metric. Please test. review and validate it. Thanks for your help !