### PR TITLE
Make DHCPv4 client (partly) RFC compliant

### DIFF
--- a/src/net/freertr/clnt/clntDhcp4.java
+++ b/src/net/freertr/clnt/clntDhcp4.java
@@ -410,7 +410,7 @@ public class clntDhcp4 implements prtServP {
         pckd.dhcpOp = packDhcp4.dhcpOpRequest;
         pckd.putParamReqList();
         pckd.dhcpClientId = true;
-        pckd.bootpCiaddr = locAddr.copyBytes();
+        pckd.dhcpServer = dhcpAddr.copyBytes();
         pckd.dhcpRequested = locAddr.copyBytes();
         pckd.createHeader(pck, null);
         sender.send2net(pck);


### PR DESCRIPTION
Remove ciaddr and added DHCP server ID in DHCPREQUEST messages, since it is MUST be filled for the first DHCP request as defined in RFC2131, section 4.4.1.

Those changes (at least) allow me to obtain an address via DHCP from my ISP. It's partly standard compliant because in renewing and rebinding state ciaddr has to be filled, but there are not such states here.