### PR TITLE
Add help message for setting ipv* address

### DIFF
--- a/src/net/freertr/ip/ipFwdIface.java
+++ b/src/net/freertr/ip/ipFwdIface.java
@@ -528,6 +528,7 @@ public class ipFwdIface extends tabRouteIface {
         l.add(null, "3 4       <addr>                    address of interface");
         l.add(null, "4 .         dynamic                 dynamic netmask");
         l.add(null, "4 .         <mask>                  subnet mask of address");
+        l.add(null, "4 .         /<num>                  subnet mask length of address");
         l.add(null, "2 3     secondary-address           set up an additional ip address");
         l.add(null, "3 .       <addr>                    address of interface");
         l.add(null, "2 3     reassembly                  set up a reassembly buffer");


### PR DESCRIPTION
To let users know that we can use CIDR notation when setting IP addresses on interfaces.

I have to read source code to know that actually I can use `ipv4 addr 10.1.1.1 /24` and `ipv6 1111::1 /127`. No one would write `ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe` for /127 manually if they know they can.