### PR TITLE
corrected cfg/intop2-ospf10.tst

### DIFF
--- a/cfg/intop2-ospf10.tst
+++ b/cfg/intop2-ospf10.tst
@@ -1,7 +1,5 @@
 description interop2: ospf p2mp te
 
-exit
-
 addrouter r1
 int eth1 eth 0000.0000.1111 $per1$
 !
@@ -56,7 +54,7 @@ interface tunnel1
 
 addpersist r2
 int eth1 eth 0000.0000.2222 $per1$
-int eth2 eth 0000.0000.2222 $per1$
+int eth2 eth 0000.0000.2222 $per2$
 !
 interface loopback0
  ipv4 addr 2.2.2.2 255.255.255.255


### PR DESCRIPTION
corrected r2:eth2 link name `$per2$` instead of `$per1$`